### PR TITLE
Add support for `define=true` and make it the default

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -9,7 +9,7 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
 deps = ["InteractiveUtils"]
-git-tree-sha1 = "63ef72675d232cbcab6da9c840168bbea08cbe0a"
+git-tree-sha1 = "26232b43c5445182a1acbd13258bfbd5be5a1dae"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -277,7 +277,7 @@ function correct_name!(stack, frame, pc, name, parentname)
         if name != cname
             replacename!(frame.code.code.code, name=>cname)
         end
-        name = pc_expr(frame, pctop).args[1]
+        name = pc_expr(frame, pctop-1).args[1]
     end
     return name, pc
 end

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -261,7 +261,8 @@ function correct_name!(stack, frame, pc, name, parentname)
     else
         pctop, isgen = nameinfo
         sigtparent, lastpcparent = signature(stack, frame, pctop)
-        methparent = whichtt(sigtparent)::Method
+        methparent = whichtt(sigtparent)
+        methparent === nothing && return name, pc  # caller isn't defined, no correction is needed
         if isgen
             cname = nameof(methparent.generator.gen)
         else

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -50,6 +50,14 @@ ismethod(stmt)  = isexpr(stmt, :method)
 ismethod1(stmt) = isexpr(stmt, :method, 1)
 ismethod3(stmt) = isexpr(stmt, :method, 3)
 
+function methodname(name)
+    isa(name, Symbol) && return name
+    if isa(name, CodeInfo) && length(name.code) == 1 && isexpr(name.code[1], :return) && ismethod1(name.code[1].args[1])
+        return name.code[1].args[1].args[1]
+    end
+    error("unhandled name type ", typeof(name))
+end
+
 """
     nextpc = next_or_nothing(frame, pc)
 
@@ -174,6 +182,7 @@ end
 
 function get_parentname(name)
     isa(name, Expr) && return name
+    name = methodname(name)
     isa(name, Symbol) || error("unhandled name type ", typeof(name))
     namestring = String(name)
     if namestring[1] == '#'

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,6 +121,17 @@ end
     @test length(signatures) == 1
     @test LoweredCodeUtils.whichtt(signatures[1]) == first(methods(Lowering.fouter))
 
+    # Check positioning in correct_name!
+    ex = :(g(x::Int8; y=0) = y)
+    Core.eval(Lowering, ex)
+    frame = JuliaInterpreter.prepare_thunk(Lowering, ex)
+    pc = frame.pc[]
+    stmt = JuliaInterpreter.pc_expr(frame, pc)
+    name = stmt.args[1]
+    parentname = LoweredCodeUtils.get_parentname(name)
+    name, pc = LoweredCodeUtils.correct_name!(JuliaStackFrame[], frame, pc, name, parentname)
+    @test name == parentname
+
     # Anonymous functions in method signatures
     ex = :(max_values(T::Union{map(X -> Type{X}, Base.BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))  # base/abstractset.jl
     frame = JuliaInterpreter.prepare_thunk(Base, ex)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,7 +127,7 @@ end
     frame = JuliaInterpreter.prepare_thunk(Lowering, ex)
     pc = frame.pc[]
     stmt = JuliaInterpreter.pc_expr(frame, pc)
-    name = stmt.args[1]
+    name = LoweredCodeUtils.methodname(stmt.args[1])
     parentname = LoweredCodeUtils.get_parentname(name)
     name, pc = LoweredCodeUtils.correct_name!(empty!(stack), frame, pc, name, parentname)
     @test name == parentname

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,6 +132,16 @@ end
     name, pc = LoweredCodeUtils.correct_name!(empty!(stack), frame, pc, name, parentname)
     @test name == parentname
 
+    # Check output of methoddef!
+    frame = JuliaInterpreter.prepare_thunk(Lowering, :(function nomethod end))
+    ret = methoddef!(empty!(signatures), empty!(stack), frame; define=true)
+    @test isempty(signatures)
+    @test ret === nothing
+    frame = JuliaInterpreter.prepare_thunk(Lowering, :(function amethod() nothing end))
+    ret = methoddef!(empty!(signatures), empty!(stack), frame; define=true)
+    @test !isempty(signatures)
+    @test isa(ret, NTuple{2,JuliaInterpreter.JuliaProgramCounter})
+
     # Anonymous functions in method signatures
     ex = :(max_values(T::Union{map(X -> Type{X}, Base.BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))  # base/abstractset.jl
     frame = JuliaInterpreter.prepare_thunk(Base, ex)


### PR DESCRIPTION
Revise's workflow is to delete missing methods and then add new definitions. We might as well evaluate those definitions when computing signatures, especially since the signature might fail unless we have defined them first.

This also throws in a number of other bugfixes organized into independent commits.