### PR TITLE
Update to the new JuliaInterpreter API

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -19,7 +19,7 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JuliaInterpreter]]
 deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
-git-tree-sha1 = "e9c35ace4c7d92483cc7cb30ab8a6cb4ae187c8a"
+git-tree-sha1 = "1ebe1d27567b0bda44fb47e4c1bdee3a58c8cfc0"
 repo-rev = "master"
 repo-url = "https://github.com/JuliaDebug/JuliaInterpreter.jl.git"
 uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -183,12 +183,12 @@ end
             end
         end
     end
-    frame = JuliaInterpreter.prepare_thunk(Lowering, ex)
+    frame = JuliaInterpreter.prepare_thunk(Base, ex)
     empty!(signatures)
     stmt = JuliaInterpreter.pc_expr(frame)
     if !LoweredCodeUtils.ismethod(stmt)
         pc = JuliaInterpreter.next_until!(LoweredCodeUtils.ismethod, frame, true)
     end
-    pc, pc3 = methoddef!(signatures, frame; define=true)  # this tests that the return isn't `nothing`
+    pc, pc3 = methoddef!(signatures, frame; define=false)  # this tests that the return isn't `nothing`
     @test length(signatures) == 2  # both the GeneratedFunctionStub and the main method
 end


### PR DESCRIPTION
Once this passes tests, I'll merge and register. This is the only remaining new package registration that's needed for Revise to switch to an implementation based on JuliaInterpreter (https://github.com/timholy/Revise.jl/pull/243). That means we could be ready as early as Saturday, if all of the packages seem solid enough (but if others are not ready, we can wait longer).