### PR TITLE
Ensure that anonymous functions get defined

### DIFF
--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -348,6 +348,12 @@ function methoddef!(@nospecialize(recurse), signatures, frame::Frame, @nospecial
         meth = whichtt(sigt)
         if isa(meth, Method)
             push!(signatures, meth.sig)
+        elseif stmt.args[1] == false
+            # If it's anonymous and not defined, define it
+            pc = step_expr!(recurse, frame, stmt, true)
+            meth = whichtt(sigt)
+            isa(meth, Method) && push!(signatures, meth.sig)
+            return pc, pc3
         else
             # guard against busted lookup, e.g., https://github.com/JuliaLang/julia/issues/31112
             code = framecode.src

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -191,4 +191,11 @@ end
     end
     pc, pc3 = methoddef!(signatures, frame; define=false)  # this tests that the return isn't `nothing`
     @test length(signatures) == 2  # both the GeneratedFunctionStub and the main method
+
+    # With anonymous functions in signatures
+    ex = :(const BitIntegerType = Union{map(T->Type{T}, Base.BitInteger_types)...})
+    frame = JuliaInterpreter.prepare_thunk(Lowering, ex)
+    empty!(signatures)
+    methoddefs!(signatures, frame; define=false)
+    @test !isempty(signatures)
 end


### PR DESCRIPTION
Happens even if `define=false`. This seems necessary to get tests passing on master.