### PR TITLE
update to 0.3.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
@@ -10,7 +10,7 @@ JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-JuliaInterpreter = "0.3, 0.4, 0.5"
+JuliaInterpreter = "0.3, 0.4, 0.5, 0.6"
 
 [targets]
 test = ["Test"]


### PR DESCRIPTION
To make sure that JuliaInterperter 0.6 is installable.