### PR TITLE
Ensure SlotNumbers are assigned when deciding top of signature

### DIFF
--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -455,6 +455,14 @@ function get_running_name(@nospecialize(recurse), frame, pc, name, parentname)
         return name, pc, nothing
     end
     pctop, isgen = nameinfo
+    # Sometimes signature_top---which follows SSAValue links backwards to find the first
+    # line needed to define the signature---misses out on a SlotNumber assignment.
+    # Fix https://github.com/timholy/Revise.jl/issues/422
+    stmt = pc_expr(frame, pctop)
+    while pctop > 1 && isa(stmt, SlotNumber) && !isassigned(frame.framedata.locals, pctop)
+        pctop -= 1
+        stmt = pc_expr(frame, pctop)
+    end   # end fix
     sigtparent, lastpcparent = signature(recurse, frame, pctop)
     sigtparent === nothing && return name, pc, lastpcparent
     methparent = whichtt(sigtparent)


### PR DESCRIPTION
A generated function with `where` upper bounds applied to one of its parameters seems to break the signature-detection logic. In the added test, here's a print out of `id: stmt` in the key portion of the framecode:

```julia
10: $(Expr(:method, :fneg))
11: JuliaInterpreter.SlotNumber(1) = ($(QuoteNode(TypeVar)))(Symbol("#s4"), FloatingTypes)
12: JuliaInterpreter.SlotNumber(1)
13: ($(QuoteNode(Core.apply_type)))(LT, JuliaInterpreter.SlotNumber(1))
14: ($(QuoteNode(UnionAll)))(JuliaInterpreter.SSAValue(12), JuliaInterpreter.SSAValue(13))
15: ($(QuoteNode(TypeVar)))(:T, JuliaInterpreter.SSAValue(14))
16: ($(QuoteNode(Core.Typeof)))(fneg)
17: ($(QuoteNode(Core.svec)))(JuliaInterpreter.SSAValue(16), JuliaInterpreter.SSAValue(15))
18: ($(QuoteNode(Core.svec)))(JuliaInterpreter.SSAValue(15))
19: ($(QuoteNode(Core.svec)))(JuliaInterpreter.SSAValue(17), JuliaInterpreter.SSAValue(18))
20: $(Expr(:method, :fneg, JuliaInterpreter.SSAValue(19), CodeInfo(quote
    $(Expr(:meta, :generated, :(%new(Core.GeneratedFunctionStub, var"#s17#2", Any[Symbol("#self#"), :x], Any[:T], 338, Symbol("/home/tim/.julia/dev/LoweredCodeUtils/test/runtests.jl"), false))))
    $(Expr(:meta, :generated_only))
    return
end)))
```

During the renaming step, `signature_top` works starting from the 3-arg `:method` (`id = 20`) and follows the chain of `SSAValue` links backwards to find the lowest `id` upon which the signature depends. In this case it came up with the answer 12, but that `SlotNumber` gets assigned on line 11.

Now, it seems possible that we could just go backwards up to the first line after the 1-arg `:method`, but since the rules for lowering are undocumented and I can't remember what I learned from poking at a bunch of examples a long time ago, I'm not sure that would be safe (think local functions, anonymous functions, etc.) So this is a very narrow fix.

Fixes https://github.com/timholy/Revise.jl/issues/422