### PR TITLE
Fixes and API extensions to serve as foundation for Revise 3.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.0.0"
+version = "1.1.0"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"

--- a/docs/src/edges.md
+++ b/docs/src/edges.md
@@ -182,7 +182,7 @@ Code:
 Here the edges are printed right after each line.
 
 !!! note
-    Useful output from `print_with_code` requires at least version 1.6.0-DEV.95 of Julia.
+    "Nice" output from `print_with_code` requires at least version 1.6.0-DEV.95 of Julia.
 
 Suppose we want to evaluate just the lines needed to compute `s`.
 We can find out which lines these are with

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -16,8 +16,8 @@ const SSAValues = Union{Core.Compiler.SSAValue, JuliaInterpreter.SSAValue}
 const structheads = VERSION >= v"1.5.0-DEV.702" ? () : (:struct_type, :abstract_type, :primitive_type)
 const trackedheads = (:method, structheads...)
 
-export signature, rename_framemethods!, methoddef!, methoddefs!, bodymethod, CodeEdges,
-       lines_required, lines_required!, selective_eval!, selective_eval_fromstart!
+export signature, rename_framemethods!, methoddef!, methoddefs!, bodymethod
+export CodeEdges, lines_required, lines_required!, selective_eval!, selective_eval_fromstart!
 
 include("utils.jl")
 include("signatures.jl")

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -1,5 +1,9 @@
 module LoweredCodeUtils
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@optlevel"))
+    @eval Base.Experimental.@optlevel 1
+end
+
 using Core: SimpleVector, CodeInfo, NewvarNode, GotoNode
 using Base.Meta: isexpr
 using JuliaInterpreter

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -4,7 +4,7 @@ using Core: SimpleVector, CodeInfo, NewvarNode, GotoNode
 using Base.Meta: isexpr
 using JuliaInterpreter
 using JuliaInterpreter: SSAValue, SlotNumber, Frame
-using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, whichtt,
+using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_quotenode, whichtt,
                         next_until!, finish_and_return!, get_return, nstatements, codelocation
 
 const SSAValues = Union{Core.Compiler.SSAValue, JuliaInterpreter.SSAValue}

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -284,7 +284,7 @@ function add_links!(target::Pair{<:Any,Links}, @nospecialize(stmt), cl::CodeLink
             cl.namesuccs[stmt] = namestore = Links()
         end
         push!(namestore, targetid)
-    elseif isa(stmt, Expr)
+    elseif isa(stmt, Expr) && stmt.head !== :copyast
         arng = 1:length(stmt.args)
         if stmt.head === :call
             f = stmt.args[1]

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -264,6 +264,8 @@ function add_links!(target::Pair{<:Any,Links}, @nospecialize(stmt), cl::CodeLink
         for i in arng
             add_links!(target, stmt.args[i], cl)
         end
+    elseif isa(stmt, QuoteNode)
+        add_links!(target, stmt.value, cl)
     end
     return nothing
 end

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -548,6 +548,13 @@ function lines_required!(isrequired::AbstractVector{Bool}, objs, src::CodeInfo, 
                     changed |= !isrequired[idxlast]
                     isrequired[idxlast] = true
                 end
+                for ibb in bb.succs
+                    ibb == length(bbs.blocks) && continue
+                    rpred = rng(bbs.blocks[ibb])
+                    idxlast = rpred[end]
+                    changed |= !isrequired[idxlast]
+                    isrequired[idxlast] = true
+                end
             end
         end
         # In preparation for the next round, add any new named objects

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -43,7 +43,7 @@ function signature(@nospecialize(recurse), frame::Frame, @nospecialize(stmt), pc
     while !isexpr(stmt, :method, 3)  # wait for the 3-arg version
         if isexpr(stmt, :thunk) && isanonymous_typedef(stmt.args[1])
             lastpc = pc = define_anonymous(recurse, frame, stmt)
-        elseif isexpr(stmt, :call) && JuliaInterpreter.is_quotenode(stmt.args[1], Core.Typeof) &&
+        elseif isexpr(stmt, :call) && is_quotenode(stmt.args[1], Core.Typeof) &&
                (sym = stmt.args[2]; isa(sym, Symbol) && !isdefined(mod, sym))
             return nothing, pc
         else

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -32,12 +32,95 @@ function getcallee(@nospecialize(stmt))
     error(stmt, " is not a call expression")
 end
 
+function callee_matches(f, mod, sym)
+    is_global_ref(f, mod, sym) && return true
+    if isdefined(mod, sym)
+        is_quotenode(f, getfield(mod, sym)) && return true  # a consequence of JuliaInterpreter.optimize!
+    end
+    return false
+end
+
+function rhs(stmt)
+    isexpr(stmt, :(=)) && return stmt.args[2]
+    return stmt
+end
+
 ismethod(frame::Frame)  = ismethod(pc_expr(frame))
 ismethod3(frame::Frame) = ismethod3(pc_expr(frame))
 
 ismethod(stmt)  = isexpr(stmt, :method)
 ismethod1(stmt) = isexpr(stmt, :method, 1)
 ismethod3(stmt) = isexpr(stmt, :method, 3)
+
+# anonymous function types are defined in a :thunk expr with a characteristic CodeInfo
+function isanonymous_typedef(stmt)
+    if isa(stmt, Expr)
+        stmt.head === :thunk || return false
+        stmt = stmt.args[1]
+    end
+    if isa(stmt, CodeInfo)
+        src = stmt    # just for naming consistency
+        length(src.code) >= 4 || return false
+        if VERSION >= v"1.5.0-DEV.702"
+            stmt = src.code[end-1]
+            (isexpr(stmt, :call) && is_global_ref(stmt.args[1], Core, :_typebody!)) || return false
+            name = stmt.args[2]::Symbol
+            return startswith(String(name), "#")
+        else
+            stmt = src.code[end-1]
+            isexpr(stmt, :struct_type) || return false
+            name = stmt.args[1]::Symbol
+            return startswith(String(name), "#")
+        end
+    end
+    return false
+end
+
+function istypedef(stmt)
+    if isa(stmt, Expr)
+        stmt = rhs(stmt)
+        if isa(stmt, Expr)
+            stmt.head ∈ structheads && return true
+            @static if isdefined(Core, :_structtype)
+                if stmt.head === :call
+                    f = stmt.args[1]
+                    if is_global_ref(f, Core, :_structype)     || is_quotenode(f, Core._structtype) ||
+                        is_global_ref(f, Core, :_abstracttype)  || is_quotenode(f, Core._abstracttype) ||
+                        is_global_ref(f, Core, :_primitivetype) || is_quotenode(f, Core._primitivetype)
+                        return true
+                    end
+                end
+            end
+            isanonymous_typedef(stmt) && return true
+        end
+    end
+    return false
+end
+
+# Given a typedef at `src.code[idx]`, return the range of statement indices that encompass the typedef.
+# The range does not include any constructor methods.
+function typedef_range(src::CodeInfo, idx)
+    stmt = src.code[idx]
+    istypedef(stmt) || error(stmt, " is not a typedef")
+    isanonymous_typedef(stmt) && return idx:idx
+    # Search backwards to the previous :global
+    istart = idx
+    while istart >= 1
+        isexpr(src.code[istart], :global) && break
+        istart -= 1
+    end
+    istart >= 1 || error("no initial :global found")
+    iend, n = idx, length(src.code)
+    while iend <= n
+        stmt = src.code[iend]
+        if isa(stmt, Expr)
+            (stmt.head === :global || stmt.head === :return) && break
+        end
+        iend += 1
+    end
+    iend <= n || (@show src; error("no final :global found"))
+    return istart:iend-1
+end
 
 """
     nextpc = next_or_nothing(frame, pc)
@@ -96,3 +179,10 @@ showempty(list) = isempty(list) ? '∅' : list
 
 # Smooth the transition between Core.Compiler and Base
 rng(bb::Core.Compiler.BasicBlock) = (r = bb.stmts; return Core.Compiler.first(r):Core.Compiler.last(r))
+
+function pushall!(dest, src)
+    for item in src
+        push!(dest, item)
+    end
+    return dest
+end

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -227,6 +227,18 @@ end
     selective_eval_fromstart!(frame, isrequired, true)
     @test supertype(ModEval.StructParent) === AbstractArray
 
+    # Anonymous functions
+    ex = :(max_values(T::Union{map(X -> Type{X}, Base.BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))
+    frame = JuliaInterpreter.prepare_thunk(ModSelective, ex)
+    src = frame.framecode.src
+    edges = CodeEdges(src)
+    isrequired = fill(false, length(src.code))
+    @assert Meta.isexpr(src.code[end-1], :method, 3)
+    isrequired[end-1] = true
+    lines_required!(isrequired, src, edges)
+    selective_eval_fromstart!(frame, isrequired, true)
+    @test ModSelective.max_values(Int16) === 65536
+
     @testset "Display" begin
         # worth testing because this has proven quite crucial for debugging and
         # ensuring that these structures are as "self-documenting" as possible.

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -208,7 +208,7 @@ end
     edges = CodeEdges(src)
     # Check that the StructParent name is discovered everywhere it is used
     var = edges.byname[:StructParent]
-    @test var.preds[1] ∈ var.succs
+    @test var.preds[end] ∈ var.succs
     isrequired = minimal_evaluation(src, edges)
     selective_eval_fromstart!(frame, isrequired, true)
     @test supertype(ModSelective.StructParent) === AbstractArray

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -210,11 +210,14 @@ end
     @test ModSelective.k11 == 0
     @test 3 <= ModSelective.s11 <= 15
 
-    # Control-flow in a structure definition
+    # Control-flow in an abstract type definition
     ex = :(abstract type StructParent{T, N} <: AbstractArray{T, N} end)
     frame = JuliaInterpreter.prepare_thunk(ModSelective, ex)
     src = frame.framecode.src
     edges = CodeEdges(src)
+    # Check that the StructParent name is discovered everywhere it is used
+    var = edges.byname[:StructParent]
+    @test var.preds[1] ∈ var.succs
     isrequired = minimal_evaluation(src, edges)
     selective_eval_fromstart!(frame, isrequired, true)
     @test supertype(ModSelective.StructParent) === AbstractArray


### PR DESCRIPTION
This fixes a number of cases where "pursuit" of slotnumbers was incomplete, where names were missed because they were in `QuoteNodes`, and especially numerous issues surrounding type (re)definition. This seems pretty solid, as judged by the fact that a rewrite of Revise to use CodeEdges seems to be working.