### PR TITLE
methoddefs!: check signature equality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,8 @@ julia = "1"
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Parameters", "Test"]
+test = ["InteractiveUtils", "Parameters", "Pkg", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -11,10 +11,9 @@ JuliaInterpreter = "0.8"
 julia = "1"
 
 [extras]
-CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["CBinding", "InteractiveUtils", "Parameters", "Test"]
+test = ["InteractiveUtils", "Parameters", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.2.2"
+version = "1.2.3"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
@@ -11,9 +11,10 @@ JuliaInterpreter = "0.8"
 julia = "1"
 
 [extras]
+CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Parameters", "Test"]
+test = ["CBinding", "InteractiveUtils", "Parameters", "Test"]

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -459,6 +459,9 @@ function methoddef!(@nospecialize(recurse), signatures, frame::Frame, @nospecial
                 if !startswith(String(ft.name.name), "##")
                     @warn "file $(loc.file), line $(loc.line): no method found for $sigt"
                 end
+                if pc == pc3
+                    pc = next_or_nothing!(frame)
+                end
             end
         end
         frame.pc = pc

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -20,8 +20,17 @@ const FloatingTypes = Union{Float32, Float64}
 end
 
 # Stuff for https://github.com/timholy/Revise.jl/issues/550
-module Lowering550
-using CBinding
+if Base.VERSION >= v"1.1"
+    try
+        using CBinding
+    catch
+        @info "Adding CBinding to the environment for test purposes"
+        using Pkg
+        Pkg.add("CBinding")    # not available for Julia 1.0
+    end
+    eval(:(module Lowering550
+    using CBinding
+    end))
 end
 
 bodymethtest0(x) = 0
@@ -377,15 +386,17 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     @test typeof(Lowering422.fneg) ∈ Set(Base.unwrap_unionall(sig).parameters[1] for sig in signatures)
 
     # https://github.com/timholy/Revise.jl/issues/550
-    ex = :(@cstruct S {
-        val::Int8
-      })
-    empty!(signatures)
-    Core.eval(Lowering550, ex)
-    frame = Frame(Lowering550, ex)
-    rename_framemethods!(frame)
-    pc = methoddefs!(signatures, frame; define=false)
-    @test !isempty(signatures)   # really we just need to know that `methoddefs!` completed without getting stuck
+    if Base.VERSION >= v"1.1"
+        ex = :(@cstruct S {
+            val::Int8
+        })
+        empty!(signatures)
+        Core.eval(Lowering550, ex)
+        frame = Frame(Lowering550, ex)
+        rename_framemethods!(frame)
+        pc = methoddefs!(signatures, frame; define=false)
+        @test !isempty(signatures)   # really we just need to know that `methoddefs!` completed without getting stuck
+    end
 
     # Undefined names
     # This comes from FileWatching; WindowsRawSocket is only defined on Windows

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -19,6 +19,11 @@ const LT{T} = Union{LVec{<:Any, T}, T}
 const FloatingTypes = Union{Float32, Float64}
 end
 
+# Stuff for https://github.com/timholy/Revise.jl/issues/550
+module Lowering550
+using CBinding
+end
+
 bodymethtest0(x) = 0
 function bodymethtest0(x)
     y = 2x
@@ -370,6 +375,17 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     rename_framemethods!(frame)
     pc = methoddefs!(signatures, frame; define=false)
     @test typeof(Lowering422.fneg) ∈ Set(Base.unwrap_unionall(sig).parameters[1] for sig in signatures)
+
+    # https://github.com/timholy/Revise.jl/issues/550
+    ex = :(@cstruct S {
+        val::Int8
+      })
+    empty!(signatures)
+    Core.eval(Lowering550, ex)
+    frame = Frame(Lowering550, ex)
+    rename_framemethods!(frame)
+    pc = methoddefs!(signatures, frame; define=false)
+    @test !isempty(signatures)   # really we just need to know that `methoddefs!` completed without getting stuck
 
     # Undefined names
     # This comes from FileWatching; WindowsRawSocket is only defined on Windows


### PR DESCRIPTION
Formerly, our "noop" signature addition (which failed to advance pc) did
not check exact signature-equality in the manner of what had been
implicitly assumed to be a condition for this branch.
This "mostly-one-line" change fixes that.

Fixes https://github.com/timholy/Revise.jl/issues/550
Fixes https://github.com/timholy/Revise.jl/issues/547