### PR TITLE
real fix for selective interpretation of toplevel definitions

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -9,6 +9,7 @@ const SSAValues = Union{Core.Compiler.SSAValue, JuliaInterpreter.SSAValue}
 
 const structheads = VERSION >= v"1.5.0-DEV.702" ? () : (:struct_type, :abstract_type, :primitive_type)
 const trackedheads = (:method, structheads...)
+const structdecls = (:_structtype, :_abstracttype, :_primitivetype)
 
 export signature, rename_framemethods!, methoddef!, methoddefs!, bodymethod
 export CodeEdges, lines_required, lines_required!, selective_eval!, selective_eval_fromstart!

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,11 +87,14 @@ function istypedef(stmt)
     stmt = rhs(stmt)
     isa(stmt, Expr) || return false
     stmt.head ∈ structheads && return true
-    @static if isdefined(Core, :_structtype)
+    @static if all(s->isdefined(Core,s), structdecls)
+        if isexpr(stmt, :(=))
+            stmt = (stmt::Expr).args[2] # look for lhs
+        end
         if stmt.head === :call
             f = stmt.args[1]
             if isa(f, GlobalRef)
-                f.mod === Core && f.name ∈ (:_structype, :_abstracttype, :_primitivetype) && return true
+                f.mod === Core && f.name ∈ structdecls && return true
             end
             if isa(f, QuoteNode)
                 (f.value === Core._structtype || f.value === Core._abstracttype ||


### PR DESCRIPTION
yay, I found the root problem of #47 ; it's just a typo lol 😂  now we can interpret toplevel definitions selectively, and it turns out we don't need Revise-like predicates but we just need `istypedef` afaict.
I also added hopefully plenty of test cases, which may help to maintain this feature in the future.