### PR TITLE
Small tweaks to reduce the need for inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "1.2.6"
+version = "1.2.7"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 
 [compat]
-JuliaInterpreter = "0.8"
+JuliaInterpreter = "0.8.8"
 julia = "1"
 
 [extras]

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -11,7 +11,7 @@ struct Links
     slots::Vector{Int}
     names::Vector{NamedVar}
 end
-Links() = Links(Int[], Int[], Int[])
+Links() = Links(Int[], Int[], NamedVar[])
 
 function Base.show(io::IO, l::Links)
     print(io, "ssas: ", showempty(l.ssas),

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -32,10 +32,12 @@ struct CodeLinks
     nameassigns::Dict{NamedVar,Vector{Int}}
 end
 function CodeLinks(nlines::Int, nslots::Int)
-    return CodeLinks([Links() for _ = 1:nlines],
-                     [Links() for _ = 1:nlines],
-                     [Links() for _ = 1:nslots],
-                     [Links() for _ = 1:nslots],
+    makelinks(n) = [Links() for _ = 1:n]
+
+    return CodeLinks(makelinks(nlines),
+                     makelinks(nlines),
+                     makelinks(nslots),
+                     makelinks(nslots),
                      [Int[] for _ = 1:nslots],
                      Dict{NamedVar,Links}(),
                      Dict{NamedVar,Links}(),

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -42,6 +42,8 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     @assert precompile(Tuple{typeof(callchain), Vector{SelfCall}})
     @assert precompile(Tuple{typeof(callchain), Vector{NamedTuple{(:linetop, :linebody, :callee, :caller),Tuple{Int64,Int64,Symbol,Union{Bool, Symbol}}}}})
 
+    @assert precompile(CodeLinks, (Int, Int))
+    @assert precompile(CodeEdges, (Int,))
     @assert precompile(CodeEdges, (CodeInfo,))
     @assert precompile(add_links!, (Pair{Union{SSAValue,SlotNumber,NamedVar},Links}, Any, CodeLinks))
     @assert precompile(lines_required!, (Vector{Bool}, Set{NamedVar}, CodeInfo, CodeEdges))

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -143,7 +143,7 @@ function identify_framemethod_calls(frame)
             if length(tsrc.code) == 1
                 tstmt = tsrc.code[1]
                 if is_return(tstmt)
-                    tex = isa(tstmt, Expr) ? tstmt.args[1] : tstmt.val
+                    tex = JuliaInterpreter.get_return_node(tstmt)
                     if isa(tex, Expr)
                         if tex.head === :method && (methname = tex.args[1]; isa(methname, Symbol))
                             push!(refs, methname=>i)


### PR DESCRIPTION
This reduces the number of generators that need to be compiled,
fixes a minor inference issue, and adds a couple of precompiles.
All of very minor consequence, but not bad to have.

However, the fix to the `Links` constructor seems important and
slightly bizarre that it worked previously.