### PR TITLE
refactor `lines_required!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"


### PR DESCRIPTION
This refactoring will make it more easier to reuse various components
involved with `lines_required!`.

My motivation is aviatesk/JET.jl#196, where
I want to implement another version of `lines_required!`, which will be
more suitable for JET's top-level analysis (e.g. it may not respect
control-flow in most cases as opposed to `lines_required!`).

This change doesn't change any functionality, and thus I'd like to bump
minor version. I confirmed Revise.jl passes all its test cases with
these changes.