### PR TITLE
handle method signatures represented as `GlobalRef`/`QuoteNode`

### DIFF
--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -438,7 +438,8 @@ module Revise643
 
 using LoweredCodeUtils, JuliaInterpreter, Test
 
-function foogr end
+# make sure to not define `foogr` before macro expansion,
+# otherwise it will be resolved as `QuoteNode`
 macro deffoogr()
     gr = GlobalRef(__module__, :foogr) # will be lowered to `GlobalRef`
     quote


### PR DESCRIPTION
Julia allows following method definitions, but LoweredCodeUtils
(and thus Revise) can't handle them well, and it lead to the issue
<https://github.com/timholy/Revise.jl/issues/643>:
```julia
function foogr end
macro deffoogr()
    gr = GlobalRef(__module__, :foogr) # will be lowered to `GlobalRef`
    quote
        $gr(args...) = length(args)
    end
end
@deffoogr
@show foogr(1,2,3) # => 3

function fooqn end
macro deffooqn()
    sig = :($(GlobalRef(__module__, :fooqn))(args...)) # will be lowered to `QuoteNode`
    return Expr(:function, sig, Expr(:block, __source__, :(length(args))))
end
@deffooqn
@show fooqn(1,2,3) # => 3
```

---

- fixes https://github.com/timholy/Revise.jl/issues/643
- fixes https://github.com/timholy/Revise.jl/issues/616