### PR TITLE
follow up #66, allow method definition in other module

### DIFF
--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -154,7 +154,6 @@ function identify_framemethod_calls(frame)
         elseif ismethod1(stmt)
             key = stmt.args[1]
             key = normalize_defsig(key, frame)
-            key === missing && continue
             key = key::Symbol
             mi = get(methodinfos, key, nothing)
             if mi === nothing
@@ -165,7 +164,6 @@ function identify_framemethod_calls(frame)
         elseif ismethod3(stmt)
             key = stmt.args[1]
             key = normalize_defsig(key, frame)
-            key === missing && continue
             if key isa Symbol
                 mi = methodinfos[key]
                 mi.stop = i
@@ -216,10 +214,8 @@ end
 # try to normalize `def` to `Symbol` representation
 function normalize_defsig(@nospecialize(def), frame::Frame)
     if def isa QuoteNode
-        parentmodule(def.value) === moduleof(frame) || return false
         def = nameof(def.value)
     elseif def isa GlobalRef
-        def.mod === moduleof(frame) || return false
         def = def.name
     end
     return def


### PR DESCRIPTION
Sorry for dirty follow up.

I found JuliaInterpreter can define a method even if its module isn't
same as `moduleof(frame::Frame)`, so the previous module context
checks are not necessary.