### PR TITLE
Switch to `is_quotenode_egal` for invalidation-resistance

### DIFF
--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -11,7 +11,7 @@ module LoweredCodeUtils
 
 using JuliaInterpreter
 using JuliaInterpreter: SSAValue, SlotNumber, Frame
-using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_quotenode, whichtt,
+using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_quotenode_egal, whichtt,
                         next_until!, finish_and_return!, get_return, nstatements, codelocation, linetable,
                         is_return, lookup_return, is_GotoIfNot, is_ReturnNode
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,10 +135,10 @@ function typedef_range(src::CodeInfo, idx)
             (stmt.head === :global || stmt.head === :return) && break
             if stmt.head === :call
                 if (is_global_ref(stmt.args[1], Core, :_typebody!) ||
-                    isdefined(Core, :_typebody!) && is_quotenode(stmt.args[1], Core._typebody!))
+                    isdefined(Core, :_typebody!) && is_quotenode_egal(stmt.args[1], Core._typebody!))
                     have_typebody = true
                 elseif (is_global_ref(stmt.args[1], Core, :_equiv_typedef) ||
-                    isdefined(Core, :_equiv_typedef) && is_quotenode(stmt.args[1], Core._equiv_typedef))
+                    isdefined(Core, :_equiv_typedef) && is_quotenode_egal(stmt.args[1], Core._equiv_typedef))
                     have_equivtypedef = true
                     # Advance to the type-assignment
                     while iend <= n


### PR DESCRIPTION
Packages that specialize `==` could invalidate the former code,
this makes it resistant.