### PR TITLE
update to upstream lowering change

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -76,9 +76,17 @@ function isanonymous_typedef(stmt)
     if isa(stmt, CodeInfo)
         src = stmt    # just for naming consistency
         length(src.code) >= 4 || return false
-        stmt = src.code[end-1]
-        (isexpr(stmt, :call) && is_global_ref(stmt.args[1], Core, :_typebody!)) || return false
-        name = (stmt::Expr).args[2]::Symbol
+        @static if VERSION ≥ v"1.9.0-DEV.391"
+            stmt = src.code[end-2]
+            isexpr(stmt, :(=)) || return false
+            name = stmt.args[1]
+            isa(name, Symbol) || return false
+        else
+            stmt = src.code[end-1]
+            isexpr(stmt, :call) || return false
+            is_global_ref(stmt.args[1], Core, :_typebody!) || return false
+            name = stmt.args[2]::Symbol
+        end
         return startswith(String(name), "#")
     end
     return false


### PR DESCRIPTION
Lowering for a closure construct has been changed by JuliaLang/julia#44974 as like:
```julia
julia> using LoweredCodeUtils, JuliaInterpreter

julia> ex = quote
               function fouter(x)
                   finner(::Float16) = 2x
                   return finner(Float16(1))
               end
           end
quote
    #= REPL[19]:2 =#
    function fouter(x)
        #= REPL[19]:2 =#
        #= REPL[19]:3 =#
        finner(::Float16) = begin
                #= REPL[19]:3 =#
                2x
            end
        #= REPL[19]:4 =#
        return finner(Float16(1))
    end
end

julia> Core.eval(@__MODULE__, ex)
fouter (generic function with 1 method)

julia> Frame(@__MODULE__, ex).framecode.src
```

```diff
diff --git a/before.jl b/after.jl
index 24b26cb..728d385 100644
--- a/before.jl
+++ b/after.jl
@@ -12,9 +12,9 @@ CodeInfo(
 │        const var"#finner#2"
 │        Core.TypeVar(:x, Core.Any)
 │   %4 = Core._structtype(Main, Symbol("#finner#2"), Core.svec(%3), Core.svec(:x), Core.svec(), false, 1)
+│        Core._setsuper!(%4, Core.Function)
 │        var"#finner#2" = %4
-│        Core._setsuper!(var"#finner#2", Core.Function)
-│        Core._typebody!(var"#finner#2", Core.svec(%3))
+│        Core._typebody!(%4, Core.svec(%3))
 └──      return nothing
 )))
 │       ($(QuoteNode(Core.svec)))(var"#finner#2", Float16)
```