### PR TITLE
Iterate control-flow graph to convergence

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -720,32 +720,37 @@ function add_control_flow!(isrequired, cfg, norequire)
     changed = false
     blocks = cfg.blocks
     nblocks = length(blocks)
-    for (ibb, bb) in enumerate(blocks)
-        r = rng(bb)
-        if any(view(isrequired, r))
-            if ibb != nblocks
-                idxlast = r[end]
-                idxlast ∈ norequire && continue
-                changed |= !isrequired[idxlast]
-                isrequired[idxlast] = true
-            end
-            for ibbp in bb.preds
-                ibbp > 0 || continue # see Core.Compiler.compute_basic_blocks, near comment re :enter
-                rpred = rng(blocks[ibbp])
-                idxlast = rpred[end]
-                idxlast ∈ norequire && continue
-                changed |= !isrequired[idxlast]
-                isrequired[idxlast] = true
-            end
-            for ibbs in bb.succs
-                ibbs == nblocks && continue
-                rpred = rng(blocks[ibbs])
-                idxlast = rpred[end]
-                idxlast ∈ norequire && continue
-                changed |= !isrequired[idxlast]
-                isrequired[idxlast] = true
+    _changed = true
+    while _changed
+        _changed = false
+        for (ibb, bb) in enumerate(blocks)
+            r = rng(bb)
+            if any(view(isrequired, r))
+                if ibb != nblocks
+                    idxlast = r[end]
+                    idxlast ∈ norequire && continue
+                    _changed |= !isrequired[idxlast]
+                    isrequired[idxlast] = true
+                end
+                for ibbp in bb.preds
+                    ibbp > 0 || continue # see Core.Compiler.compute_basic_blocks, near comment re :enter
+                    rpred = rng(blocks[ibbp])
+                    idxlast = rpred[end]
+                    idxlast ∈ norequire && continue
+                    _changed |= !isrequired[idxlast]
+                    isrequired[idxlast] = true
+                end
+                for ibbs in bb.succs
+                    ibbs == nblocks && continue
+                    rpred = rng(blocks[ibbs])
+                    idxlast = rpred[end]
+                    idxlast ∈ norequire && continue
+                    _changed |= !isrequired[idxlast]
+                    isrequired[idxlast] = true
+                end
             end
         end
+        changed |= _changed
     end
     return changed
 end

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -128,6 +128,25 @@ end
     @test ModSelective.a3 === ModEval.a3 == 2
     @test allmissing(ModSelective, (:z3, :x3, :y3))
 
+    ex = quote
+        if Sys.iswindows()
+             const ONLY_ON_WINDOWS = true
+        end
+        c_os = if Sys.iswindows()
+            ONLY_ON_WINDOWS
+        else
+            false
+        end
+    end
+    frame = Frame(ModSelective, ex)
+    src = frame.framecode.src
+    edges = CodeEdges(src)
+    isrequired = lines_required(:c_os, src, edges)
+    @test sum(isrequired) >= length(isrequired) - 2
+    selective_eval_fromstart!(frame, isrequired)
+    Core.eval(ModEval, ex)
+    @test ModSelective.c_os === ModEval.c_os == Sys.iswindows()
+
     # Capturing dependencies of an `@eval` statement
     interpT = Expr(:$, :T)   # $T that won't get parsed during file-loading
     ex = quote


### PR DESCRIPTION
We only analyze a block if it's needed, but that means that we need to
repeat the analysis until we stop adding new blocks.
Future work might optimize this if it proves to be a performance
bottleneck, but until then this solution is easy.

xref https://github.com/timholy/Revise.jl/pull/721#issuecomment-1367914123

Easier to see what changed with `Hide whitespace` checked.