### PR TITLE
Fix tests on 1.8 & nightly

### DIFF
--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -609,6 +609,9 @@ function bodymethod(mkw::Method)
                 has_self_call(src, src.code[id]) || return m
             end
             f = stmt.args[end-2]
+            if isa(f, JuliaInterpreter.SSAValue)
+                f = src.code[f.id]
+            end
         else
             has_self_call(src, stmt) || return m
         end

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -279,7 +279,7 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     rename_framemethods!(frame)
     empty!(signatures)
     methoddefs!(signatures, frame; define=false)
-    @test length(signatures) >= 3
+    @test length(signatures) >= 3 - isdefined(Core, :kwcall)
 
     ex = :(typedsig(x) = 1)
     frame = Frame(Lowering, ex)
@@ -350,8 +350,10 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     @test length(ks) == 2
     @test dct[ks[1]] == dct[ks[2]]
     @test isdefined(Lowering, ks[1]) || isdefined(Lowering, ks[2])
-    nms = filter(sym->occursin(r"#Items#\d+#\d+", String(sym)), names(Lowering; all=true))
-    @test length(nms) == 1
+    if !isdefined(Core, :kwcall)
+        nms = filter(sym->occursin(r"#Items#\d+#\d+", String(sym)), names(Lowering; all=true))
+        @test length(nms) == 1
+    end
 
     # https://github.com/timholy/Revise.jl/issues/422
     ex = :(@generated function fneg(x::T) where T<:LT{<:FloatingTypes}


### PR DESCRIPTION
This package never got updated for changes in lowering in Julia 1.8.
Moreover, other changes were made for 1.9. This gets the existing test
suite passing, in part by disabling some of the specific tests on recent
Julia versions. The disabled tests check for fairly specific features
of lowering, and those features have not proven to be particularly
durable. Hopefully none of them were testing anything with significant
functional consequences. Revise will be a good testbed, but for it to
pass we'll also need #73.