### PR TITLE
Update CI & use Documenter 1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,6 @@ jobs:
         version:
           - '1.6'     # current LTS
           - '1'       # latest stable
-          - '1.10-nightly' # next stable
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 /Manifest.toml
+/docs/Manifest.toml

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+LoweredCodeUtils = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 
 [compat]
-Documenter = "0.24"
+Documenter = "1"


### PR DESCRIPTION
Now that 1.10 is out, I don't think we need to test `1.10-nightly`. CC @aviatesk in case this should be bumped to 1.11 instead.