### PR TITLE
Don't scan for 3-arg method if there is none

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -96,6 +96,8 @@ function ismethod_with_name(src, stmt, target::AbstractString; reentrant::Bool=f
             isdone = true
         end
     end
+    # On Julia 1.6 we have to add escaping (CBinding makes function names like "(S)")
+    target = escape_string(target, "()")
     return match(Regex("(^|#)$target(\$|#)"), string(name)) !== nothing
 end
 


### PR DESCRIPTION
This is the primary portion of the fix for
https://github.com/timholy/Revise.jl/issues/758