### PR TITLE
Add failing test for proper termination

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -902,17 +902,6 @@ function add_control_flow!(isrequired, src, cfg, domtree, postdomtree)
                 # end
             end
         end
-        if !ok
-            print_with_code(stdout, src, isrequired)
-            @show ibb jbb ipbb
-            ipbb = postdomtree.idoms_bb[ibb]
-            print("ibb postdoms: ")
-            while ipbb != 0
-                print(ipbb, " ")
-                ipbb = postdomtree.idoms_bb[ipbb]
-            end
-            println()
-        end
         jbb <= length(blocks) && @assert ok
     end
     return changed
@@ -953,7 +942,7 @@ function add_typedefs!(isrequired, src::CodeInfo, edges::CodeEdges, (typedef_blo
         stmt = stmts[idx]
         isrequired[idx] == true || (idx += 1; continue)
         for (typedefr, typedefn) in zip(typedef_blocks, typedef_names)
-            if idx ∈ typedefr
+            if idx ∈ typedefr && !iscf(stmt)  # exclude control-flow nodes since they may be needed for other purposes
                 ireq = view(isrequired, typedefr)
                 if !all(==(true), ireq)
                     changed = true

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -21,6 +21,7 @@ if Base.VERSION < v"1.10"
 else
     const construct_domtree = Core.Compiler.construct_domtree
     const construct_postdomtree = Core.Compiler.construct_postdomtree
+    const dominates = Core.Compiler.dominates
     const postdominates = Core.Compiler.postdominates
 end
 
@@ -46,10 +47,8 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     isrequired = lines_required(GlobalRef(@__MODULE__, :s), src, edges)
     lines_required(GlobalRef(@__MODULE__, :s), src, edges; norequire=())
     lines_required(GlobalRef(@__MODULE__, :s), src, edges; norequire=exclude_named_typedefs(src, edges))
-    for isreq in (isrequired, convert(Vector{Bool}, isrequired))
-        lines_required!(isreq, src, edges; norequire=())
-        lines_required!(isreq, src, edges; norequire=exclude_named_typedefs(src, edges))
-    end
+    lines_required!(isrequired, src, edges; norequire=())
+    lines_required!(isrequired, src, edges; norequire=exclude_named_typedefs(src, edges))
     frame = Frame(@__MODULE__, src)
     # selective_eval_fromstart!(frame, isrequired, true)
     precompile(selective_eval_fromstart!, (typeof(frame), typeof(isrequired), Bool))  # can't @eval during precompilation

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -216,6 +216,23 @@ module ModSelective end
     @test ModSelective.k11 == 0
     @test 3 <= ModSelective.s11 <= 15
 
+    # Final block is not a `return`
+    ex = quote
+        x = 1
+        y = 7
+        @label loop
+        x += 1
+        x < 5 || return y
+        @goto loop
+    end
+    frame = Frame(ModSelective, ex)
+    src = frame.framecode.src
+    edges = CodeEdges(src)
+    isrequired = lines_required(:x, src, edges)
+    selective_eval_fromstart!(frame, isrequired, true)
+    @test ModSelective.x == 5
+    @test !isdefined(ModSelective, :y)
+
     # Control-flow in an abstract type definition
     ex = :(abstract type StructParent{T, N} <: AbstractArray{T, N} end)
     frame = Frame(ModSelective, ex)

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -219,10 +219,10 @@ module ModSelective end
     # Final block is not a `return`
     ex = quote
         x = 1
-        y = 7
+        yy = 7
         @label loop
         x += 1
-        x < 5 || return y
+        x < 5 || return yy
         @goto loop
     end
     frame = Frame(ModSelective, ex)
@@ -231,7 +231,7 @@ module ModSelective end
     isrequired = lines_required(GlobalRef(ModSelective, :x), src, edges)
     selective_eval_fromstart!(frame, isrequired, true)
     @test ModSelective.x == 5
-    @test !isdefined(ModSelective, :y)
+    @test !isdefined(ModSelective, :yy)
 
     # Control-flow in an abstract type definition
     ex = :(abstract type StructParent{T, N} <: AbstractArray{T, N} end)
@@ -326,7 +326,7 @@ module ModSelective end
         if iblock == length(bbs.blocks)
             @test any(idx->isrequired[idx]==true, r)
         else
-            @test !any(idx->isrequired[idx]==true, r)
+            @test !any(idx->isrequired[idx]==true && !LoweredCodeUtils.iscf(src.code[idx]), r)
         end
     end
 

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -488,7 +488,9 @@ end
         stmts = src.code
         edges = CodeEdges(m, src)
 
-        isrq = lines_required!(istypedef.(stmts), src, edges)
+        isrq = LoweredCodeUtils.initialize_isrequired(length(stmts))
+        copyto!(isrq, istypedef.(stmts))
+        lines_required!(isrq, src, edges)
         frame = Frame(m, src)
         selective_eval_fromstart!(frame, isrq, #=toplevel=#true)
 

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -324,9 +324,9 @@ module ModSelective end
     for (iblock, block) in enumerate(bbs.blocks)
         r = LoweredCodeUtils.rng(block)
         if iblock == length(bbs.blocks)
-            @test any(idx->isrequired[idx], r)
+            @test any(idx->isrequired[idx]==true, r)
         else
-            @test !any(idx->isrequired[idx], r)
+            @test !any(idx->isrequired[idx]==true, r)
         end
     end
 

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -414,9 +414,10 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     oldenv = Pkg.project().path
     try
         # we test with the old version of CBinding, let's do it in an isolated environment
+        # so we don't cause package conflicts with everything else
         Pkg.activate(; temp=true, io=devnull)
 
-        @info "Adding CBinding to the environment for test purposes"
+        @info "Adding CBinding 0.9.4 to the environment for test purposes"
         Pkg.add(; name="CBinding", version="0.9.4", io=devnull) # `@cstruct` isn't defined for v1.0 and above
 
         m = Module()


### PR DESCRIPTION
This is related to recent work on handling control-flow properly. In brief, this PR contains an example for which our current approach fails and which seems to require a breaking change to fix. @aviatesk, since JET is the only other (besides Revise) direct dependent of LoweredCodeUtils, I thought we should coordinate about this before I take any steps to implement this.

#### Longer version:

Currently we use a heuristic to avoid marking the exit of the last basic block, expecting it to be a `return` and so that execution will cease whether we evaluate it or not. However, it is possible to write code for which the final statement is a `GotoNode` and in this case we can get incorrect answers if we fail to evaluate it.

This example illustrates a tricky point: `return` both terminates execution but may also return a value. If we don't require the value, we still might need to terminate execution. This example seems to illustrate that having `isrequired[i]` be either `true` or `false` may be insufficiently expressive; we might need it to be three states, `:no`, `:yes`, `:exit`. During marking, encountering `:exit` would not force one to evaluate the returned SSAValue.

