### PR TITLE
Adjust to upcoming compiler change

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -384,7 +384,6 @@ Analyze `src` and determine the chain of dependencies.
   for an object `v::$NamedVar`.
 """
 function CodeEdges(src::CodeInfo)
-    src.inferred && error("supply lowered but not inferred code")
     cl = CodeLinks(src)
     CodeEdges(src, cl)
 end


### PR DESCRIPTION
The `.inferred` field is being removed in [1], so delete the assertion.

[1] https://github.com/JuliaLang/julia/pull/53219