### PR TITLE
Track `GlobalRef` consistently

### DIFF
--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -42,10 +42,10 @@ if ccall(:jl_generating_output, Cint, ()) == 1
     end
     lwr = Meta.lower(@__MODULE__, ex)
     src = lwr.args[1]
-    edges = CodeEdges(src)
-    isrequired = lines_required(:s, src, edges)
-    lines_required(:s, src, edges; norequire=())
-    lines_required(:s, src, edges; norequire=exclude_named_typedefs(src, edges))
+    edges = CodeEdges(@__MODULE__, src)
+    isrequired = lines_required(GlobalRef(@__MODULE__, :s), src, edges)
+    lines_required(GlobalRef(@__MODULE__, :s), src, edges; norequire=())
+    lines_required(GlobalRef(@__MODULE__, :s), src, edges; norequire=exclude_named_typedefs(src, edges))
     for isreq in (isrequired, convert(Vector{Bool}, isrequired))
         lines_required!(isreq, src, edges; norequire=())
         lines_required!(isreq, src, edges; norequire=exclude_named_typedefs(src, edges))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,6 +85,8 @@ function ismethod_with_name(src, stmt, target::AbstractString; reentrant::Bool=f
             name = src.code[name.id]
         elseif isexpr(name, :call) && is_quotenode_egal(name.args[1], Core.svec)
             name = name.args[2]
+        elseif isexpr(name, :call) && is_quotenode_egal(name.args[1], Core.Typeof)
+            name = name.args[2]
         elseif isexpr(name, :call) && is_quotenode_egal(name.args[1], Core.apply_type)
             for arg in name.args[2:end]
                 ismethod_with_name(src, arg, target; reentrant=true) && return true
@@ -120,7 +122,11 @@ function isanonymous_typedef(stmt)
             stmt = isa(stmt.args[3], Core.SSAValue) ? src.code[end-3] : src.code[end-2]
             isexpr(stmt, :(=)) || return false
             name = stmt.args[1]
-            isa(name, Symbol) || return false
+            if isa(name, GlobalRef)
+                name = name.name
+            else
+                isa(name, Symbol) || return false
+            end
         else
             name = stmt.args[2]::Symbol
         end


### PR DESCRIPTION
Currently dependencies for `GlobalRef` and `Symbol` are tracked separately. Unfortunately, our lowering is not consistent about which one it uses (after lowering, all `Symbols` refer to globals in the current module), so the same variable can appear twice in the same expression, once as a globalref, once as a symbol. Currently, in that situation, this package misses a dependency, because it considers them two separate objects. Fix that by always normalizing to GlobalRef. This does require the caller to pass through a Module, but the alternative, would be for the caller to keep track of these dependencies implicitly, which would be painful. I think consistently usign `GlobalRef` here is cleanest.