### PR TITLE
Fix a `Core.Box`

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -543,19 +543,6 @@ function postprint_lineedges(io::IO, idx::Int, edges::CodeEdges, bbchanged::Bool
 end
 
 function terminal_preds(i::Int, edges::CodeEdges)
-    function terminal_preds!(s, j, edges, covered)
-        j ∈ covered && return s
-        push!(covered, j)
-        preds = edges.preds[j]
-        if isempty(preds)
-            push!(s, j)
-        else
-            for p in preds
-                terminal_preds!(s, p, edges, covered)
-            end
-        end
-        return s
-    end
     s, covered = BitSet(), BitSet()
     push!(covered, i)
     for p in edges.preds[i]
@@ -563,6 +550,20 @@ function terminal_preds(i::Int, edges::CodeEdges)
     end
     return s
 end
+function terminal_preds!(s, j, edges, covered)  # can't be an inner function because it calls itself (Core.Box)
+    j ∈ covered && return s
+    push!(covered, j)
+    preds = edges.preds[j]
+    if isempty(preds)
+        push!(s, j)
+    else
+        for p in preds
+            terminal_preds!(s, p, edges, covered)
+        end
+    end
+    return s
+end
+
 
 """
     isrequired = lines_required(obj::GlobalRef, src::CodeInfo, edges::CodeEdges)


### PR DESCRIPTION
This is presumably a Julia limitation, but it seems that inner functions
get inferred as `Core.Box` if they call themselves. We can work around
it by splitting it out.

Specifically, in Cthulhu one sees

    for p in preds
        terminal_preds!::Core.Box(s, p, edges, covered)
    end

when this is an inner function.

If this has been fixed on Julia nightly (JET doesn't work there so it is harder for me to check), then let's close this without merging.