### PR TITLE
allow overload for `next_or_nothing!`

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -943,7 +943,7 @@ function selective_eval!(@nospecialize(recurse), frame::Frame, isrequired::Abstr
         if te
             pcexec = pc = step_expr!(recurse, frame, istoplevel)
         else
-            pc = next_or_nothing!(frame)
+            pc = next_or_nothing!(recurse, frame)
         end
     end
     isa(pc, BreakpointRef) && return pc

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -493,7 +493,7 @@ function methoddef!(@nospecialize(recurse), signatures, frame::Frame, @nospecial
         sigt, pc = signature(recurse, frame, stmt, pc)
         meth = whichtt(sigt)
         if isa(meth, Method) && (meth.sig <: sigt && sigt <: meth.sig)
-            pc = define ? step_expr!(recurse, frame, stmt, true) : next_or_nothing!(frame)
+            pc = define ? step_expr!(recurse, frame, stmt, true) : next_or_nothing!(recurse, frame)
         elseif define
             pc = step_expr!(recurse, frame, stmt, true)
             meth = whichtt(sigt)
@@ -517,7 +517,7 @@ function methoddef!(@nospecialize(recurse), signatures, frame::Frame, @nospecial
                     @warn "file $(loc.file), line $(loc.line): no method found for $sigt"
                 end
                 if pc == pc3
-                    pc = next_or_nothing!(frame)
+                    pc = next_or_nothing!(recurse, frame)
                 end
             end
         end
@@ -560,7 +560,7 @@ function methoddef!(@nospecialize(recurse), signatures, frame::Frame, @nospecial
         # Methods like f(x::Ref{<:Real}) that use gensymmed typevars will not have the *exact*
         # signature of the active method. So let's get the active signature.
         frame.pc = pc
-        pc = define ? step_expr!(recurse, frame, stmt, true) : next_or_nothing!(frame)
+        pc = define ? step_expr!(recurse, frame, stmt, true) : next_or_nothing!(recurse, frame)
         meth = whichtt(sigt)
         isa(meth, Method) && push!(signatures, meth.sig) # inner methods are not visible
         name === name3 && return pc, pc3     # if this was an inner method we should keep going

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -210,11 +210,11 @@ Advance the program counter without executing the corresponding line.
 If `frame` is finished, `nextpc` will be `nothing`.
 """
 next_or_nothing(frame, pc) = pc < nstatements(frame.framecode) ? pc+1 : nothing
-function next_or_nothing!(frame)
+next_or_nothing!(frame) = next_or_nothing(finish_and_return!, frame)
+function next_or_nothing!(@nospecialize(recurse), frame)
     pc = frame.pc
     if pc < nstatements(frame.framecode)
-        frame.pc = pc = pc + 1
-        return pc
+        return frame.pc = pc + 1
     end
     return nothing
 end


### PR DESCRIPTION
I am writing a solution for JuliaDebug/LoweredCodeUtils.jl#99 by overloading `next_or_nothing!`. This PR serves as a preparation for that, while the basic usage of LCU remains unchanged.