### PR TITLE
Prepare for https://github.com/JuliaLang/julia/pull/56036

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -112,13 +112,23 @@ function print_with_code(preprint, postprint, io::IO, src::CodeInfo)
     for stmt in src.code
         Core.Compiler.scan_ssa_use!(push!, used, stmt)
     end
+    @static if VERSION > v"1.11" && __has_internal_change(v"1.12-alpha", :printcodeinfocalls)
+        parent = src.parent
+        sptypes = if parent isa MethodInstance
+            Core.Compiler.sptypes_from_meth_instance(parent)
+        else Core.Compiler.EMPTY_SPTYPES end
+    end
     line_info_preprinter = Base.IRShow.lineinfo_disabled
     line_info_postprinter = Base.IRShow.default_expr_type_printer
     preprint(io)
     bb_idx_prev = bb_idx = 1
     for idx = 1:length(src.code)
         preprint(io, idx)
-        bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
+        @static if VERSION > v"1.11" && __has_internal_change(v"1.12-alpha", :printcodeinfocalls)
+            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, sptypes, used, cfg, bb_idx)
+        else
+            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
+        end
         postprint(io, idx, bb_idx != bb_idx_prev)
         bb_idx_prev = bb_idx
     end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/56036 expands some of the IR information available to code printing. 

This PR adapts to that change to avoid breaking Revise once it lands.