### PR TITLE
Restore `trackedheads`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "3.2.0"
+version = "3.2.1"
 
 [deps]
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 
 [compat]
-JuliaInterpreter = "0.9"
+JuliaInterpreter = "0.9.44"
 julia = "1.10"
 
 [extras]

--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -11,7 +11,7 @@ module LoweredCodeUtils
 
 using JuliaInterpreter
 using JuliaInterpreter: SSAValue, SlotNumber, Frame
-using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_quotenode_egal, whichtt,
+using JuliaInterpreter: @lookup, moduleof, pc_expr, step_expr!, is_global_ref, is_global_ref_egal, is_quotenode_egal, whichtt,
                         next_until!, finish_and_return!, get_return, nstatements, codelocation, linetable,
                         is_return, lookup_return
 

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -192,6 +192,13 @@ function namedkeys(cl::CodeLinks)
     return ukeys
 end
 
+# Required by Revise, but otherwise deprecated
+# The depwarn is currently disabled because Revise's tests check for empty warning logs
+function is_assignment_like(@nospecialize stmt)
+    # Base.depwarn("is_assignment_like is deprecated, switch to `LoweredCodeUtils.get_lhs_rhs`", :is_assignment_like)
+    return isexpr(stmt, :(=)) || isexpr(stmt, :const, 2)
+end
+
 function get_lhs_rhs(@nospecialize stmt)
     if isexpr(stmt, :(=))
         return Pair{Any,Any}(stmt.args[1], stmt.args[2])
@@ -199,7 +206,7 @@ function get_lhs_rhs(@nospecialize stmt)
         return Pair{Any,Any}(stmt.args[1], stmt.args[2])
     elseif isexpr(stmt, :call) && length(stmt.args) == 4
         f = stmt.args[1]
-        if isa(f, GlobalRef) && f.name === :setglobal!
+        if is_global_ref_egal(f, :setglobal!, Core.setglobal!)
             mod = stmt.args[2]
             mod isa Module || return nothing
             name = stmt.args[3]

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -1,13 +1,17 @@
 Base.Experimental.@optlevel 1
 
 using Core: SimpleVector
-using Core.IR
+using Core.IR: CodeInfo, GotoIfNot, GotoNode, IR, MethodInstance, ReturnNode
+@static if isdefined(Core.IR, :EnterNode)
+    using Core.IR: EnterNode
+end
 using Core.Compiler: construct_domtree, construct_postdomtree, nearest_common_dominator,
     postdominates
 using Base.Meta: isexpr
 
 const SSAValues = Union{Core.Compiler.SSAValue, JuliaInterpreter.SSAValue}
 
+const trackedheads = (:method,)    # Revise uses this (for now), don't delete; also update test/hastrackedexpr if this list gets expanded
 const structdecls = (:_structtype, :_abstracttype, :_primitivetype)
 
 export signature, rename_framemethods!, methoddef!, methoddefs!, bodymethod


### PR DESCRIPTION
- Fixes https://github.com/timholy/Revise.jl/issues/906
- removes a compilation warning about conflict in SSAValue and
  SlotNumber.
- improves handling of `setglobal!`