### PR TITLE
Recognize Core.declare_const in get_lhs_rhs

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -203,10 +203,12 @@ function get_lhs_rhs(@nospecialize stmt)
     if isexpr(stmt, :(=))
         return Pair{Any,Any}(stmt.args[1], stmt.args[2])
     elseif isexpr(stmt, :const) && length(stmt.args) == 2
+        # TODO: remove lowered :const when Julia min compat >= 1.13
         return Pair{Any,Any}(stmt.args[1], stmt.args[2])
     elseif isexpr(stmt, :call) && length(stmt.args) == 4
         f = stmt.args[1]
-        if is_global_ref_egal(f, :setglobal!, Core.setglobal!)
+        # TODO: remove isdefined when Julia min compat >= 1.13
+        if is_global_ref_egal(f, :setglobal!, Core.setglobal!) || @static isdefined(Core, :declare_const) && is_global_ref_egal(f, :declare_const,  Core.declare_const)
             mod = stmt.args[2]
             mod isa Module || return nothing
             name = stmt.args[3]


### PR DESCRIPTION
This is the minimal change to get Revise working with ~~JuliaLang/julia#57470~~ https://github.com/JuliaLang/julia/pull/58187.

Comparison of lowering of `const foo = 1`:
| version | |
|-|-|
| 1.11 | `Expr(:const, :foo), Expr(:(=), :foo, 1)` (with edge 2 -> 1) |
| 1.12 | `Expr(:const, :foo, 1)` |
| 1.13 | `Expr(:call, Core.declare_const, :foo, 1)` |