### PR TITLE
use the stdlib version of Compiler instead of `Core.Compiler`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,14 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.3.1"
+version = "3.4.0"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]
+Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 
 [compat]
+Compiler = "0.1"
 JuliaInterpreter = "0.10"
 julia = "1.10"
 

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -106,13 +106,13 @@ function print_with_code(preprint, postprint, io::IO, src::CodeInfo)
     used = BitSet()
     cfg = compute_basic_blocks(src.code)
     for stmt in src.code
-        Core.Compiler.scan_ssa_use!(push!, used, stmt)
+        CC.scan_ssa_use!(push!, used, stmt)
     end
     @static if isdefined(Base, :__has_internal_change) && Base.__has_internal_change(v"1.12-alpha", :printcodeinfocalls)
         sptypes = let parent = src.parent
             parent isa MethodInstance ?
-                Core.Compiler.sptypes_from_meth_instance(parent) :
-                Core.Compiler.EMPTY_SPTYPES
+                CC.sptypes_from_meth_instance(parent) :
+                CC.EMPTY_SPTYPES
         end
     end
     line_info_preprinter = Base.IRShow.lineinfo_disabled
@@ -763,8 +763,6 @@ end
 
 ## Add control-flow
 
-using Core: CodeInfo
-using Core.Compiler: CFG, BasicBlock, compute_basic_blocks
 
 # The goal of this function is to request concretization of the minimal necessary control
 # flow to evaluate statements whose concretization have already been requested.

--- a/src/domtree.jl
+++ b/src/domtree.jl
@@ -5,7 +5,6 @@
 
 # A few items needed to be added:
 
-using Core.Compiler: BasicBlock
 import Base: length, copy, copy!
 
 # END additions

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -5,11 +5,14 @@ using Core.IR: CodeInfo, GotoIfNot, GotoNode, IR, MethodInstance, ReturnNode
 @static if isdefined(Core.IR, :EnterNode)
     using Core.IR: EnterNode
 end
-using Core.Compiler: construct_domtree, construct_postdomtree, nearest_common_dominator,
-    postdominates
+using Compiler: Compiler as CC
+using .CC:
+    BasicBlock, CFG,
+    compute_basic_blocks, construct_domtree, construct_postdomtree,
+    nearest_common_dominator, postdominates
 using Base.Meta: isexpr
 
-const SSAValues = Union{Core.Compiler.SSAValue, JuliaInterpreter.SSAValue}
+const SSAValues = Union{Core.IR.SSAValue, JuliaInterpreter.SSAValue}
 
 const trackedheads = (:method,)    # Revise uses this (for now), don't delete; also update test/hastrackedexpr if this list gets expanded
 const structdecls = (:_structtype, :_abstracttype, :_primitivetype)

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -2,6 +2,7 @@ module codeedges
 
 using LoweredCodeUtils
 using LoweredCodeUtils.JuliaInterpreter
+using LoweredCodeUtils: CC
 using LoweredCodeUtils: callee_matches, istypedef, exclude_named_typedefs
 using JuliaInterpreter: is_global_ref, is_quotenode
 using Test
@@ -324,7 +325,7 @@ module ModSelective end
     src = frame.framecode.src
     edges = CodeEdges(ModEval, src)
     isrequired = minimal_evaluation(@nospecialize(stmt)->(LoweredCodeUtils.ismethod3(stmt),false), src, edges; norequire=exclude_named_typedefs(src, edges))  # initially mark only the constructor
-    bbs = Core.Compiler.compute_basic_blocks(src.code)
+    bbs = CC.compute_basic_blocks(src.code)
     for (iblock, block) in enumerate(bbs.blocks)
         r = LoweredCodeUtils.rng(block)
         if iblock == length(bbs.blocks)

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -319,7 +319,7 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     methoddefs!(signatures, frame; define=false)
     @test !isempty(signatures)
 
-    # Inner methods in structs. Comes up in, e.g., Core.Compiler.Params.
+    # Inner methods in structs. Comes up in, e.g., CC.Params.
     # The body of CustomMS is an SSAValue.
     ex = quote
         struct MyStructWithMeth


### PR DESCRIPTION
This allows `Compiler.CFG` created from tools like JET to be passed directly to LCU then.