### PR TITLE
Use Compiler.IRShow instead of Base.IRShow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.4.0"
+version = "3.4.1"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
 
 [deps]

--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -115,16 +115,16 @@ function print_with_code(preprint, postprint, io::IO, src::CodeInfo)
                 CC.EMPTY_SPTYPES
         end
     end
-    line_info_preprinter = Base.IRShow.lineinfo_disabled
-    line_info_postprinter = Base.IRShow.default_expr_type_printer
+    line_info_preprinter = IRShow.lineinfo_disabled
+    line_info_postprinter = IRShow.default_expr_type_printer
     preprint(io)
     bb_idx_prev = bb_idx = 1
     for idx = 1:length(src.code)
         preprint(io, idx)
         @static if isdefined(Base, :__has_internal_change) && Base.__has_internal_change(v"1.12-alpha", :printcodeinfocalls)
-            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, sptypes, used, cfg, bb_idx)
+            bb_idx = IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, sptypes, used, cfg, bb_idx)
         else
-            bb_idx = Base.IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
+            bb_idx = IRShow.show_ir_stmt(io, src, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
         end
         postprint(io, idx, bb_idx != bb_idx_prev)
         bb_idx_prev = bb_idx

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -9,7 +9,8 @@ using Compiler: Compiler as CC
 using .CC:
     BasicBlock, CFG,
     compute_basic_blocks, construct_domtree, construct_postdomtree,
-    nearest_common_dominator, postdominates
+    nearest_common_dominator, postdominates,
+    IRShow
 using Base.Meta: isexpr
 
 const SSAValues = Union{Core.IR.SSAValue, JuliaInterpreter.SSAValue}

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -9,8 +9,14 @@ using Compiler: Compiler as CC
 using .CC:
     BasicBlock, CFG,
     compute_basic_blocks, construct_domtree, construct_postdomtree,
-    nearest_common_dominator, postdominates,
-    IRShow
+    nearest_common_dominator, postdominates
+
+@static if isdefined(CC, :IRShow)
+    using .CC: IRShow
+else
+    using Base: IRShow
+end
+
 using Base.Meta: isexpr
 
 const SSAValues = Union{Core.IR.SSAValue, JuliaInterpreter.SSAValue}


### PR DESCRIPTION
Otherwise, `Base.IRShow` methods end up requiring `Base.Compiler` types, which will be incompatible with any non-fallback `Compiler` implementation.