### PR TITLE
Move a using statement into the correct location for VS Code ext

### DIFF
--- a/src/LoweredCodeUtils.jl
+++ b/src/LoweredCodeUtils.jl
@@ -14,6 +14,7 @@ using JuliaInterpreter: SSAValue, SlotNumber, Frame, Interpreter, RecursiveInter
 using JuliaInterpreter: codelocation, is_global_ref, is_global_ref_egal, is_quotenode_egal, is_return,
                         lookup, lookup_return, linetable, moduleof, next_until!, nstatements, pc_expr,
                         step_expr!, whichtt
+using Compiler: Compiler as CC
 
 include("packagedef.jl")
 

--- a/src/packagedef.jl
+++ b/src/packagedef.jl
@@ -5,7 +5,6 @@ using Core.IR: CodeInfo, GotoIfNot, GotoNode, IR, MethodInstance, ReturnNode
 @static if isdefined(Core.IR, :EnterNode)
     using Core.IR: EnterNode
 end
-using Compiler: Compiler as CC
 using .CC:
     BasicBlock, CFG,
     compute_basic_blocks, construct_domtree, construct_postdomtree,


### PR DESCRIPTION
Otherwise we can't use this in the VS Code extension world.