### PR TITLE
Provide more robustness for some lowering differences

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -156,8 +156,10 @@ end
 function is_declare_global(@nospecialize(stmt))
     isexpr(stmt, :call) || return false
     f = stmt.args[1]
-    is_global_ref(f, Core, :declare_global) && return true
-    is_quotenode_egal(f, Core.declare_global) && return true
+    @static if isdefined(Core, :declare_global)
+        is_global_ref(f, Core, :declare_global) && return true
+        is_quotenode_egal(f, Core.declare_global) && return true
+    end
     return false
 end
 


### PR DESCRIPTION
This allows some variants for struct lowering, in particular using the `declare_` intrinsic rather than `=` and allowing an assignment around `typebody!`.
This was developed with https://github.com/JuliaLang/julia/pull/60569. This may or may not be needed in the final version of that PR, but it's good for this code to be less brittle there regardless since those are reasonable lowerings.