### PR TITLE
Don't march through code for a forward declaration

### DIFF
--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -587,14 +587,26 @@ function methoddef!(interp::Interpreter, signatures::Vector{MethodInfoKey}, fram
         Base.invokelatest(error, "given invalid definition: ", stmt)
     end
     name = name::GlobalRef
-    # Is there any 3-arg method definition with the same name? If not, avoid risk of executing code that
-    # we shouldn't (fixes https://github.com/timholy/Revise.jl/issues/758)
+    # Is there a 3-arg method definition that completes this opening? If not, avoid the
+    # risk of executing code that we shouldn't (fixes https://github.com/timholy/Revise.jl/issues/758).
+    # A bare `function foo end` only forward-declares `foo`; its real definition (if any)
+    # may be separated by unrelated top-level code. Marching to a far-away method via the
+    # loop below would execute that intervening code, which is wrong when we are only
+    # extracting signatures (https://github.com/timholy/Revise.jl/issues/706). So accept
+    # the opening only when its matching `:method` is reached before any unrelated
+    # top-level definition. Anonymous and gensymmed (`#…`) methods are the helper/inner
+    # methods of this definition (closures, keyword bodies, generator stubs); a method
+    # with an ordinary user-level name marks the start of an unrelated definition.
     found = false
     for i = pc+1:length(framecode.src.code)
         newstmt = framecode.src.code[i]
         if ismethod3(newstmt)
             if ismethod_with_name(framecode.src, newstmt, string(name.name))
                 found = true
+                break
+            end
+            othername = normalize_defsig(newstmt.args[1], frame)
+            if isa(othername, GlobalRef) && !startswith(String(othername.name), '#')
                 break
             end
         end

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -21,6 +21,11 @@ const LT{T} = Union{LVec{<:Any, T}, T}
 const FloatingTypes = Union{Float32, Float64}
 end
 
+# Stuff for https://github.com/timholy/Revise.jl/issues/706
+module Lowering706
+ran = Ref(0)
+end
+
 bodymethtest0(x) = 0
 function bodymethtest0(x)
     y = 2x
@@ -163,6 +168,23 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     ret = methoddef!(empty!(signatures), frame; define=true)
     @test !isempty(signatures)
     @test isa(ret, NTuple{2,Int})
+
+    # A bare `function foo end` only forward-declares `foo`; when its real definition is
+    # separated from it by unrelated top-level code, extracting signatures must not march
+    # through and execute that intervening code (https://github.com/timholy/Revise.jl/issues/706).
+    ex = quote
+        function fwd706 end
+        ran[] += 1            # unrelated top-level code that must not run while collecting signatures
+        unrelated706() = 1    # an unrelated, differently-named method
+        fwd706() = 2          # the real definition, after the intervening code
+    end
+    Core.eval(Lowering706, ex)   # mimic an already-loaded module, as when re-extracting signatures
+    Lowering706.ran[] = 0
+    frame = Frame(Lowering706, ex)
+    rename_framemethods!(frame)
+    ret = methoddef!(empty!(signatures), frame; define=false)
+    @test ret === nothing
+    @test Lowering706.ran[] == 0
 
     # Anonymous functions in method signatures
     ex = :(max_values(T::Union{map(X -> Type{X}, Base.BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))  # base/abstractset.jl


### PR DESCRIPTION
When extracting signatures, `methoddef!` could be handed the opening of a forward declaration (`function foo end`). Because `foo` may have a real definition far later in the frame, the existing check accepted the opening and entered the multi-trip loop, whose `signature()` calls step through (and thus execute) every top-level statement up to the next method. When the real definition is separated from the declaration by unrelated top-level code, that code was wrongly executed during signature extraction.

This is the mechanism behind Revise.jl#706: re-`:sigs` of a JLL package's main file forward-declares `is_available` near the top and defines it at the bottom, so the march executed the intervening `let` block (constructing and calling a gensymmed parametric closure whose call method is only defined with `define=false`), failing with a `MethodError` (or, on Julia 1.12, an earlier `set_binding_type!` error on the `best_wrapper` global).

Accept the opening only when its matching `:method` is reached before any unrelated top-level definition. Anonymous (`arg1 === false`) and gensymmed (`#…`) methods are the helper/inner methods of the definition being scanned (closures, keyword bodies, generator stubs) and are skipped; a method with an ordinary user-level name marks the start of an unrelated definition and ends the scan.

Fixes https://github.com/timholy/Revise.jl/issues/706