### PR TITLE
Resolve signatures at the latest committed world

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LoweredCodeUtils"
 uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
-version = "3.6.0"
-authors = ["Tim Holy <tim.holy@gmail.com>"]
+version = "3.7.0"
+authors = ["Tim Holy <tim.holy@gmail.com>", "Shuhei Kadowaki <aviatesk@gmail.com>", "and contributors"]
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -11,7 +11,7 @@ JuliaInterpreter = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
 [compat]
 CodeTracking = "3"
 Compiler = "0.1"
-JuliaInterpreter = "0.10"
+JuliaInterpreter = "0.11"
 julia = "1.10"
 
 [extras]

--- a/src/signatures.jl
+++ b/src/signatures.jl
@@ -451,7 +451,9 @@ function get_running_name(interp::Interpreter, frame::Frame, pc::Int, name::Glob
     methinfo, lastpcparent = signature(interp, frame, pctop)
     methinfo === nothing && return name, pc, lastpcparent
     mt, sigtparent = methinfo
-    methparent = whichtt(sigtparent, mt)
+    # Resolve against the live method tables at the latest committed world, not `whichtt`'s
+    # default (caller task) world, which may be older than the world this method was defined in.
+    methparent = whichtt(sigtparent, mt; world=Base.get_world_counter())
     methparent === nothing && return name, pc, lastpcparent  # caller isn't defined, no correction is needed
     if isgen
         cname = GlobalRef(moduleof(frame), nameof(methparent.generator.gen))
@@ -546,12 +548,16 @@ function methoddef!(interp::Interpreter, signatures::Vector{MethodInfoKey}, fram
         pc3 = pc
         arg1 = stmt.args[1]
         (mt, sigt), pc = signature(interp, frame, stmt, pc)
-        meth = whichtt(sigt, mt)
+        # Resolve the signature against the live method tables at the latest committed world.
+        # `whichtt`'s default world is the caller's task world, which is too old here: the method
+        # may have just been defined by `step_expr!` (advancing the world past `frame.world`), and
+        # a caller may be driving this in a task pinned to an older world (e.g. Revise revising).
+        meth = whichtt(sigt, mt; world=Base.get_world_counter())
         if isa(meth, Method) && (meth.sig <: sigt && sigt <: meth.sig)
             pc = define ? step_expr!(interp, frame, stmt, true) : next_or_nothing!(interp, frame)
         elseif define
             pc = step_expr!(interp, frame, stmt, true)
-            meth = whichtt(sigt, mt)
+            meth = whichtt(sigt, mt; world=Base.get_world_counter())
         end
         if isa(meth, Method) && (meth.sig <: sigt && sigt <: meth.sig)
             push!(signatures, MethodInfoKey(mt, meth.sig))
@@ -559,7 +565,7 @@ function methoddef!(interp::Interpreter, signatures::Vector{MethodInfoKey}, fram
             if arg1 === false || arg1 === nothing || isa(mt, MethodTable)
                 # If it's anonymous and not defined, define it
                 pc = step_expr!(interp, frame, stmt, true)
-                meth = whichtt(sigt, mt)
+                meth = whichtt(sigt, mt; world=Base.get_world_counter())
                 isa(meth, Method) && push!(signatures, MethodInfoKey(mt, meth.sig))
                 return pc, pc3
             else
@@ -629,7 +635,7 @@ function methoddef!(interp::Interpreter, signatures::Vector{MethodInfoKey}, fram
         # signature of the active method. So let's get the active signature.
         frame.pc = pc
         pc = define ? step_expr!(interp, frame, stmt, true) : next_or_nothing!(interp, frame)
-        meth = whichtt(sigt, mt)
+        meth = whichtt(sigt, mt; world=Base.get_world_counter())
         isa(meth, Method) && push!(signatures, MethodInfoKey(mt, meth.sig)) # inner methods are not visible
         name === name3 && return pc, pc3     # if this was an inner method we should keep going
         stmt = pc_expr(frame, pc)  # there *should* be more statements in this frame

--- a/test/signatures.jl
+++ b/test/signatures.jl
@@ -26,6 +26,25 @@ module Lowering706
 ran = Ref(0)
 end
 
+# Stuff for testing signature resolution when the calling task runs in an older world age
+# than the one the method was defined in (Revise drives signature extraction pinned to its
+# frozen `__init__` world via `invoke_in_world`; see Revise issue #552).
+module LoweringWorldAge
+function fworld end   # forward-declare the binding so it predates the world snapshot taken in the test
+end
+
+# Extract signatures from `ex`. Both this and `extract_signatures_in_world` are defined at top
+# level (not as closures at the call site) so they predate the world snapshot taken in the test
+# and are reachable by `invoke_in_world`.
+function collect_signatures(mod::Module, ex::Expr)
+    frame = Frame(mod, ex)
+    sigs = MethodInfoKey[]
+    methoddefs!(sigs, frame; define=false)
+    return sigs
+end
+extract_signatures_in_world(mod::Module, ex::Expr, w::UInt) =
+    Base.invoke_in_world(w, collect_signatures, mod, ex)
+
 bodymethtest0(x) = 0
 function bodymethtest0(x)
     y = 2x
@@ -185,6 +204,16 @@ bodymethtest5(x, y=Dict(1=>2)) = 5
     ret = methoddef!(empty!(signatures), frame; define=false)
     @test ret === nothing
     @test Lowering706.ran[] == 0
+
+    # Signature resolution must use the latest committed world, not the calling task's
+    # world: a method may live in a newer world than the task driving extraction (Revise
+    # revises pinned to its frozen `__init__` world via `invoke_in_world`; see Revise #552).
+    wld = Base.get_world_counter()
+    Core.eval(LoweringWorldAge, :(fworld(x::Int) = 1))   # define the method in a newer world
+    @test Base.get_world_counter() > wld
+    sigs_world = extract_signatures_in_world(LoweringWorldAge, :(fworld(x::Int) = 1), wld)
+    @test length(sigs_world) == 1
+    @test only(sigs_world) == MethodInfoKey(nothing, which(LoweringWorldAge.fworld, Tuple{Int}).sig)
 
     # Anonymous functions in method signatures
     ex = :(max_values(T::Union{map(X -> Type{X}, Base.BitIntegerSmall_types)...}) = 1 << (8*sizeof(T)))  # base/abstractset.jl


### PR DESCRIPTION
JuliaInterpreter 0.11 changed `default_world()` from the latest committed world to the caller's task world. Signature extraction must still resolve a definition against the live method tables: the method may live in a world newer than the task's, either because `step_expr!` just defined it (advancing the world past `frame.world`) or because the caller drives extraction pinned to an older world (Revise revises pinned to its frozen `__init__` world via `invoke_in_world`). So `methoddef!` and `get_running_name` now pass `world=Base.get_world_counter()` to `whichtt`; otherwise the lookup misses the method and no signature is recorded.

Project changes:
- Bump the JuliaInterpreter compat to 0.11 accordingly
- Set version to 3.7.0
- Rectify long-overdue `authors` field change