### PR TITLE
codeedges: Fix termination point placement

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -985,9 +985,10 @@ end
 function record_termination_points!(controller::SelectiveEvalController, isrequired, cfg::CFG)
     for bbidx = 1:length(cfg.blocks)
         bb = cfg.blocks[bbidx]
-        if isempty(bb.succs)
-            i = findfirst(idx::Int->!isrequired[idx], bb.stmts)
-            if !isnothing(i)
+        if isempty(bb.succs) && !isempty(bb.stmts)
+            last_required = findlast(idx::Int->isrequired[idx], bb.stmts)
+            i = isnothing(last_required) ? firstindex(bb.stmts) : last_required + 1
+            if i <= lastindex(bb.stmts)
                 push!(controller.termination_points, bb.stmts[i])
             end
         end

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -242,13 +242,39 @@ module ModSelective end
     @test ModSelective.x == 5
     @test !isdefined(ModSelective, :yy)
 
+    # Inactive statements at the beginning of a terminal block shouldn't terminate
+    # selective evaluation before later required statements in the same block.
+    let mod = Module(:ModTerminationPointAfterRequired)
+        Core.eval(mod, :(hits = Int[]))
+        ex = quote
+            if Base.inferencebarrier(true)
+                branch_value = 1
+            end
+            push!(hits, 1) # should not be called
+            push!(hits, 2)
+        end
+        frame = Frame(mod, ex)
+        src = frame.framecode.src
+        edges = CodeEdges(mod, src)
+        controller = SelectiveEvalController()
+        isrequired = fill(false, length(src.code))
+        targetidx = findlast(stmt -> Meta.isexpr(stmt, :call), src.code) # the second push!
+        isrequired[targetidx] = true
+        lines_required!(isrequired, (GlobalRef(mod, :branch_value),), src, edges, controller)
+        interp = LoweredCodeUtils.SelectiveInterpreter(
+            LoweredCodeUtils.RecursiveInterpreter(), isrequired, controller)
+        frame.pc = findfirst(isrequired)
+        JuliaInterpreter.finish_and_return!(interp, frame, true)
+        @test @invokelatest(mod.branch_value) == 1
+        @test @invokelatest(mod.hits) == [2]
+    end
+
     # Control-flow in an abstract type definition
     ex = :(abstract type StructParent{T, N} <: AbstractArray{T, N} end)
     frame = Frame(ModSelective, ex)
     src = frame.framecode.src
     edges = CodeEdges(ModSelective, src)
     # Check that the StructParent name is discovered everywhere it is used
-    var = edges.byname[GlobalRef(ModSelective, :StructParent)]
     isrequired = minimal_evaluation(hastrackedexpr, src, edges)
     selective_eval_fromstart!(frame, isrequired, #=istoplevel=#true)
     @test supertype(ModSelective.StructParent) === AbstractArray


### PR DESCRIPTION
Termination points were recorded at the simply first inactive statement of each terminal block. That could stop selective evaluation before later required statements in the same block were reached.

Record the first inactive statement after the last required statement instead, and add a regression test for a required statement that follows an inactive statement in a terminal block.