### PR TITLE
codeedges: Track EnterNode scope dependencies

### DIFF
--- a/src/codeedges.jl
+++ b/src/codeedges.jl
@@ -414,6 +414,8 @@ function add_links!(target::Pair{Union{SSAValue,SlotNumber,GlobalRef},Links}, @n
                 add_links!(target, stmt.args[i], cl)
             end
         end
+    elseif (@static @isdefined(EnterNode) ? stmt isa EnterNode : false)
+        isdefined(stmt, :scope) && add_links!(target, stmt.scope, cl)
     elseif stmt isa GotoIfNot
         add_links!(target, stmt.cond, cl)
     elseif stmt isa ReturnNode

--- a/test/codeedges.jl
+++ b/test/codeedges.jl
@@ -88,6 +88,24 @@ module ModSelective end
     selective_eval_fromstart!(frame, isrequired, #=istoplevel=#true)
     @test ModSelective.k != ModEval.k
 
+    @static if isdefined(Test, Symbol("@with_testset"))
+        let src = Meta.lower(@__MODULE__, :(@testset begin f() = 1 end)).args[1]
+            enteridx = findfirst(src.code) do stmt
+                stmt isa Core.EnterNode && isdefined(stmt, :scope)
+            end
+            @test enteridx !== nothing
+            if enteridx !== nothing
+                scope = (src.code[enteridx]::Core.EnterNode).scope
+                @test scope isa Core.SSAValue
+                if scope isa Core.SSAValue
+                    links = LoweredCodeUtils.CodeLinks(@__MODULE__, src)
+                    @test scope.id in links.ssapreds[enteridx].ssas
+                    @test enteridx in links.ssasuccs[scope.id].ssas
+                end
+            end
+        end
+    end
+
     # Control-flow
     ex = quote
         flag2 = true


### PR DESCRIPTION
`CodeLinks` did not track SSA values referenced by `EnterNode.scope`. Selective evaluation could therefore enter an uninitialized scope. Add bidirectional scope links and cover scoped testset lowering.